### PR TITLE
Use _G instead of a separate environment and remove import

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The user's home is $(os.getenv "HOME").
 ## Builtin macros
 
 * All Lua functions and modules are available as `upp` macros (see <https://www.lua.org/manual/>)
-* `input_files`: list of the input files given on the command line.
-* `output_file`: output file given on the command line.
+* `input_files()`: list of the input files given on the command line.
+* `output_file()`: output file given on the command line.
 * `upp(Lua_expression)`: evaluate a Lua expression and outputs its result.
 * `die(msg, errcode)`: print `msg` and exit with the error code `errcode`.
 * `import(script)`: evaluate a Lua script (e.g. to define new macros).

--- a/README.md
+++ b/README.md
@@ -99,12 +99,13 @@ The user's home is $(os.getenv "HOME").
 
 ## Builtin macros
 
-* All Lua functions and modules are available as `upp` macros (see <https://www.lua.org/manual/>)
+* All Lua functions and modules are available as `upp` macros (see <https://www.lua.org/manual/>).
+  E.g.:
+    * `require(module)`: import a Lua script (e.g. to define new macros, variables, ...).
 * `input_files()`: list of the input files given on the command line.
 * `output_file()`: output file given on the command line.
 * `upp(Lua_expression)`: evaluate a Lua expression and outputs its result.
 * `die(msg, errcode)`: print `msg` and exit with the error code `errcode`.
-* `import(script)`: evaluate a Lua script (e.g. to define new macros).
 * `include(filename)`: include a file in the currently preprocessed file.
 * `when(condition)(text)`: process `text` if `condition` is true.
 * `map(f, xs)`: return `{f(x) | x ∈ xs}`.
@@ -124,7 +125,7 @@ The user's home is $(os.getenv "HOME").
 ## Example
 
 ```
-Import a Lua script: :(import "script_name")
+Import a Lua script: :(require "module_name")
 Embed a Lua script: :( Lua script )
 Evaluate a Lua expression: $( 1 + lua_function(lua_variable) )
 Include another document: $(include "other_document_name")

--- a/tests/test.md
+++ b/tests/test.md
@@ -11,7 +11,7 @@
 - undefined is not defined: undefined = $(undefined)
 
 foofoo can be undefined: :(foofoo = nil)foofoo = $(foofoo)
-and redefined by reloading test_lib.lua: :(import "test_lib.lua")foofoo = $(foofoo)
+and redefined by reloading test_lib.lua: :(require "test_lib")foofoo = $(foofoo)
 
 $(include "tests/test_include.md")
 
@@ -93,7 +93,7 @@ This file uses the name of the parent file as prefix.
 
 # Standard library tests
 
-:(import "pretty")
+:(require "pretty")
 :(BLOCK_SEP = ", ")
 
 ## range:
@@ -135,7 +135,7 @@ add "/" to all items: $(map(suffix"/", {"a", "b", "c"}))
 
 ## Counters
 
-:(import "counter")
+:(require "counter")
 
 Count A's        : $(count "A") $(count "A") $(count "A")
 Count B's from 42: $(count("B", 42)) $(count "B") $(count "B")

--- a/tests/test.md
+++ b/tests/test.md
@@ -34,9 +34,9 @@ $(when(lang=="en") [[
 lang = $(lang) => You should not see this text in english!
 ]])
 
-input files: $(input_files)
+input files: $(input_files())
 
-output file: $(output_file)
+output file: $(output_file())
 
 # Blocks (array items)
 

--- a/tests/test2.md
+++ b/tests/test2.md
@@ -1,3 +1,3 @@
 # Additional tests
 
-A second file just to make sure `input_files` can contain more than one filename.
+A second file just to make sure `input_files()` can contain more than one filename.

--- a/tests/test_result.md
+++ b/tests/test_result.md
@@ -138,4 +138,4 @@ More A's         : 4 5 6
 More B's         : 45 46 47
 # Additional tests
 
-A second file just to make sure `input_files` can contain more than one filename.
+A second file just to make sure `input_files()` can contain more than one filename.

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -1,6 +1,6 @@
-/** \file $(input_files)
+/** \file $(input_files())
  *
- * Generated file: $(output_file)
+ * Generated file: $(output_file())
  */
 
 #include <assert.h>


### PR DESCRIPTION
- the document can use `_G` (explicitly or implicitly)
- `import` is obsolete (equivalent to `require`)